### PR TITLE
Redesign for efficiency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ tree-sitter-c = "0.20"
 
 [dependencies]
 tree-sitter = "0.20"
+tree-sitter-traversal = "0.1"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,7 +1,33 @@
 use tree_sitter::{Node, Tree};
+use tree_sitter_traversal::{traverse, Order};
+
+#[derive(Debug)]
+pub struct Edit {
+    pub position: usize,
+    pub delete: usize,
+    pub insert: Vec<u8>,
+}
 
 // TODO(lb): Perhaps make an associated error type so that these operations can
 // fail?
+
+pub fn default_in_order<'a, E: Editor>(
+    editor: &'a E,
+    source: &'a [u8],
+    tree: &'a Tree,
+) -> impl Iterator<Item = Edit> + 'a {
+    traverse(tree.walk(), Order::Pre).filter_map(|n| {
+        if editor.has_edit(tree, &n) {
+            Some(Edit {
+                position: n.start_byte(),
+                delete: n.end_byte() - n.start_byte(),
+                insert: editor.edit(source, tree, &n),
+            })
+        } else {
+            None
+        }
+    })
+}
 
 /// Modify a tree-sitter parse tree when printing.
 pub trait Editor {
@@ -10,4 +36,15 @@ pub trait Editor {
 
     /// Edit this node (precondition: [`Editor::has_edit`]).
     fn edit(&self, source: &[u8], tree: &Tree, node: &Node) -> Vec<u8>;
+
+    /// Get all edits to this tree, in order.
+    ///
+    /// Edits must be ordered by start byte and must not overlap.
+    ///
+    /// [`default_in_order`] does an in-order traversal of the tree.
+    fn in_order_edits<'a>(
+        &'a self,
+        source: &'a [u8],
+        tree: &'a Tree,
+    ) -> Box<dyn Iterator<Item = Edit> + 'a>;
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8,19 +8,6 @@ pub trait Editor {
     /// Does this editor have an edit for this node?
     fn has_edit(&self, tree: &Tree, node: &Node) -> bool;
 
-    /// Does this editor have an edit for some descendant of this node?
-    fn contains_edit(&self, tree: &Tree, node: &Node) -> bool {
-        let mut nodes = Vec::with_capacity(node.child_count());
-        nodes.push(*node);
-        while let Some(node) = nodes.pop() {
-            if self.has_edit(tree, &node) {
-                return true;
-            }
-            nodes.extend(node.children(&mut tree.walk()));
-        }
-        false
-    }
-
     /// Edit this node (precondition: [`Editor::has_edit`]).
     fn edit(&self, source: &[u8], tree: &Tree, node: &Node) -> Vec<u8>;
 }

--- a/src/editors/id.rs
+++ b/src/editors/id.rs
@@ -1,6 +1,6 @@
 use tree_sitter::{Node, Tree};
 
-use crate::editor::Editor;
+use crate::editor::{Edit, Editor};
 
 /// The [Editor] that makes no changes.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -22,5 +22,9 @@ impl Editor for Id {
     fn edit(&self, _source: &[u8], _tree: &Tree, _node: &Node) -> Vec<u8> {
         debug_assert!(false);
         Vec::new()
+    }
+
+    fn in_order_edits(&self, _source: &[u8], _tree: &Tree) -> Box<dyn Iterator<Item = Edit>> {
+        Box::new(std::iter::empty())
     }
 }

--- a/src/editors/left_biased_or.rs
+++ b/src/editors/left_biased_or.rs
@@ -1,6 +1,6 @@
 use tree_sitter::{Node, Tree};
 
-use crate::editor::Editor;
+use crate::editor::{default_in_order, Edit, Editor};
 
 /// An [Editor] that merges the edits from two [Editor]s, preferring the left
 /// one.
@@ -27,5 +27,13 @@ impl<L: Editor, R: Editor> Editor for LeftBiasedOr<L, R> {
             debug_assert!(self.right.has_edit(tree, node));
             self.right.edit(source, tree, node)
         }
+    }
+
+    fn in_order_edits<'a>(
+        &'a self,
+        source: &'a [u8],
+        tree: &'a Tree,
+    ) -> Box<dyn Iterator<Item = Edit> + 'a> {
+        Box::new(default_in_order(self, source, tree))
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -23,9 +23,7 @@ pub fn render(
     let mut nodes = Vec::new();
     nodes.push(tree.root_node());
     while let Some(node) = nodes.pop() {
-        if !editor.contains_edit(tree, &node) {
-            continue;
-        } else if editor.has_edit(tree, &node) {
+        if editor.has_edit(tree, &node) {
             let node_end = node.end_byte();
             let node_start = node.start_byte();
             debug_assert!(node_end >= node_start);


### PR DESCRIPTION
Don't re-traverse the tree, allow each editor to define the minimal tree traversal it needs.