### PR TITLE
Fix must_use compilation issue by moving it to the trait

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -14,6 +14,7 @@ pub struct Edit {
 /// Modify a tree-sitter parse tree when printing.
 pub trait Editor {
     /// Does this editor have an edit for this node?
+    #[must_use]
     fn has_edit(&self, tree: &Tree, node: &Node<'_>) -> bool;
 
     /// Edit this node (precondition: [`Editor::has_edit`]).

--- a/src/editors/delete.rs
+++ b/src/editors/delete.rs
@@ -18,7 +18,6 @@ impl Delete {
 }
 
 impl Editor for Delete {
-    #[must_use]
     fn has_edit(&self, _tree: &Tree, node: &Node<'_>) -> bool {
         self.id.is(node)
     }

--- a/src/editors/id.rs
+++ b/src/editors/id.rs
@@ -14,7 +14,6 @@ impl Id {
 }
 
 impl Editor for Id {
-    #[must_use]
     fn has_edit(&self, _tree: &Tree, _node: &Node<'_>) -> bool {
         false
     }


### PR DESCRIPTION
Addresses the CI failure noticed in #28.